### PR TITLE
Upgrade jemalloc to 4.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 default: cedar-14
 
-cedar-14: dist/cedar-14/jemalloc-3.6.0-1.tar.gz
+cedar-14: dist/cedar-14/jemalloc-4.2.1-1.tar.gz
 
-dist/cedar-14/jemalloc-3.6.0-1.tar.gz: jemalloc-cedar-14
+dist/cedar-14/jemalloc-4.2.1-1.tar.gz: jemalloc-cedar-14
 	docker cp $<:/tmp/jemalloc-cedar-14.tar.gz .
 	mkdir -p $$(dirname $@)
 	mv jemalloc-cedar-14.tar.gz $@
@@ -13,7 +13,7 @@ clean:
 
 src/jemalloc.tar.bz2:
 	mkdir -p $$(dirname $@)
-	curl -sL http://www.canonware.com/download/jemalloc/jemalloc-3.6.0.tar.bz2 -o $@
+	curl -sL https://github.com/jemalloc/jemalloc/releases/download/4.2.1/jemalloc-4.2.1.tar.bz2 -o $@
 
 .PHONY: cedar-14-stack
 

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ function vendor() {
 }
 
 echo "-----> Vendoring binaries"
-vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/jemalloc-3.6.0-1.tar.gz" "$BUILD_DIR/vendor/jemalloc"
+vendor "https://s3.amazonaws.com/mojodna-heroku/$STACK/jemalloc-4.2.1-1.tar.gz" "$BUILD_DIR/vendor/jemalloc"
 
 echo "-----> Configuring build environment"
 

--- a/cedar-14-stack/Dockerfile
+++ b/cedar-14-stack/Dockerfile
@@ -9,20 +9,3 @@ RUN \
 
 RUN \
   apt-get upgrade -y
-
-ADD ./postgresql.tar.gz /tmp
-RUN \
-  mkdir -p /app/vendor && \
-  cd /tmp/postgresql-* && \
-  ./configure --prefix=/app/vendor/pgsql --with-openssl
-
-RUN \
-  cd /tmp/postgresql-* && \
-  make -C src/bin install-strip && \
-  cp src/backend/utils/fmgroids.h src/include/utils/fmgroids.h && \
-  make -C src/include install-strip && \
-  make -C src/interfaces install-strip
-
-RUN \
-  cd /app/vendor/pgsql && \
-  tar zcf /tmp/pgsql-cedar-14-stack.tar.gz .


### PR DESCRIPTION
Please note I've got an error:

```
Step 6 : ADD ./postgresql.tar.gz /tmp
lstat postgresql.tar.gz: no such file or directory
make: *** [cedar-14-stack] Error 1
```

so I had to comment out lines 13-28 from cedar-14-stack while building. Have no Idea why are these lines needed.

Here's the compiled jemalloc: https://www.dropbox.com/s/hsw795xjd6lg9cs/jemalloc-4.2.1-1.tar.gz?dl=0
