### PR TITLE
Jemalloc 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,6 @@ I am a Heroku buildpack that installs
 
 ## Using
 
-To use jemalloc with your app, either prefix commands with `jemalloc.sh <cmd>`
-or set `LD_PRELOAD=/app/vendor/jemalloc/lib/libjemalloc.so.1` in your
-environment (it will then apply to all commands run).
-
-Example, in your Procfile:
-
-```
-web: jemalloc.sh bundle exec puma -C config/puma.rb
-```
-
-Setting LD_PRELOAD can sometimes mess with the building of an app - if you're seeing errors during slug compilation, try removing LD_PRELOAD and just using `jemalloc.sh`.
-
-### Composed
-
 [Heroku now supports using multiple buildpacks for an app](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
 ```bash

--- a/bin/compile
+++ b/bin/compile
@@ -58,5 +58,5 @@ export LIBRARY_PATH="\${LIBRARY_PATH:+${LIBRARY_PATH}:}${LIBRARY_PATH//$BUILD_DI
 export PKG_CONFIG_PATH="\${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}${PKG_CONFIG_PATH//$BUILD_DIR//app}"
 export CPPPATH="\${CPPPATH:+${CPPPATH}:}${CPPPATH//$BUILD_DIR//app}"
 export CPATH="\${CPATH:+${CPATH}:}${CPATH//$BUILD_DIR//app}"
-export LD_PRELOAD="/app/vendor/jemalloc/lib/libjemalloc.so.1"
+export LD_PRELOAD=`jemalloc-config --libdir`/libjemalloc.so.`jemalloc-config --revision` app
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -24,12 +24,12 @@ function vendor() {
   mkdir -p $path
   curl -sL $binary -s -o - | tar xz -C $path -f -
 
-  [ -d "$path/bin" ] && export PATH=$path/bin:$PATH
-  export CPPPATH="$path/include:$CPPPATH"
-  export CPATH="$path/include:$CPATH"
-  export LIBRARY_PATH="$path/lib:$LIBRARY_PATH"
-  export LD_LIBRARY_PATH="$path/lib:$LD_LIBRARY_PATH"
-  [ -d "$path/lib/pkgconfig" ] && export PKG_CONFIG_PATH="$path/lib/pkgconfig:$PKG_CONFIG_PATH"
+  [ -d "$path/bin" ] && export PATH=$path/bin${PATH:+:${PATH}}
+  export CPPPATH="$path/include${CPPPATH:+:${CPPPATH}}"
+  export CPATH="$path/include${CPATH:+:${CPATH}}"
+  export LIBRARY_PATH="$path/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+  export LD_LIBRARY_PATH="$path/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  [ -d "$path/lib/pkgconfig" ] && export PKG_CONFIG_PATH="$path/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 
   true
 }
@@ -40,12 +40,12 @@ vendor "https://github.com/mojodna/heroku-buildpack-jemalloc/releases/download/4
 echo "-----> Configuring build environment"
 
 cat <<EOF > export
-export PATH="$PATH:\$PATH"
-export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
-export LIBRARY_PATH="\$LIBRARY_PATH:$LIBRARY_PATH"
-export PKG_CONFIG_PATH="\$PKG_CONFIG_PATH:$PKG_CONFIG_PATH"
-export CPPPATH="\$CPPPATH:$CPPPATH"
-export CPATH="\$CPATH:$CPATH"
+export PATH="${PATH:+${PATH}:}\$PATH"
+export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export LIBRARY_PATH="\$LIBRARY_PATH${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+export PKG_CONFIG_PATH="\$PKG_CONFIG_PATH${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+export CPPPATH="\$CPPPATH${CPPPATH:+:${CPPPATH}}"
+export CPATH="\$CPATH${CPATH:+:${CPATH}}"
 EOF
 
 echo "-----> Building runtime environment"
@@ -53,10 +53,10 @@ mkdir -p $BUILD_DIR/.profile.d
 
 cat <<EOF > $BUILD_DIR/.profile.d/$BUILDPACK_NAME.sh
 export PATH="${PATH//$BUILD_DIR//app}:\$PATH"
-export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:${LD_LIBRARY_PATH//$BUILD_DIR//app}"
-export LIBRARY_PATH="\$LIBRARY_PATH:${LIBRARY_PATH//$BUILD_DIR//app}"
-export PKG_CONFIG_PATH="\$PKG_CONFIG_PATH:${PKG_CONFIG_PATH//$BUILD_DIR//app}"
-export CPPPATH="\$CPPPATH:${CPPPATH//$BUILD_DIR//app}"
-export CPATH="\$CPATH:${CPATH//$BUILD_DIR//app}"
+export LD_LIBRARY_PATH="\${LD_LIBRARY_PATH:+${LD_LIBRARY_PATH}:}${LD_LIBRARY_PATH//$BUILD_DIR//app}"
+export LIBRARY_PATH="\${LIBRARY_PATH:+${LIBRARY_PATH}:}${LIBRARY_PATH//$BUILD_DIR//app}"
+export PKG_CONFIG_PATH="\${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}${PKG_CONFIG_PATH//$BUILD_DIR//app}"
+export CPPPATH="\${CPPPATH:+${CPPPATH}:}${CPPPATH//$BUILD_DIR//app}"
+export CPATH="\${CPATH:+${CPATH}:}${CPATH//$BUILD_DIR//app}"
 export LD_PRELOAD="/app/vendor/jemalloc/lib/libjemalloc.so.1"
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -58,4 +58,5 @@ export LIBRARY_PATH="\$LIBRARY_PATH:${LIBRARY_PATH//$BUILD_DIR//app}"
 export PKG_CONFIG_PATH="\$PKG_CONFIG_PATH:${PKG_CONFIG_PATH//$BUILD_DIR//app}"
 export CPPPATH="\$CPPPATH:${CPPPATH//$BUILD_DIR//app}"
 export CPATH="\$CPATH:${CPATH//$BUILD_DIR//app}"
+export LD_PRELOAD="/app/vendor/jemalloc/lib/libjemalloc.so.1"
 EOF

--- a/bin/compile
+++ b/bin/compile
@@ -35,7 +35,7 @@ function vendor() {
 }
 
 echo "-----> Vendoring binaries"
-vendor "https://github.com/mojodna/heroku-buildpack-jemalloc/releases/download/5.0.0/jemalloc-5.0.0-1.tar.gz" "$BUILD_DIR/vendor/jemalloc"
+vendor "https://github.com/mojodna/heroku-buildpack-jemalloc/releases/download/v5.0.0/jemalloc-5.0.0-1.tar.gz" "$BUILD_DIR/vendor/jemalloc"
 
 echo "-----> Configuring build environment"
 


### PR DESCRIPTION
This PR contains a fix for the LD_PRELOAD issue #6. This fix only applies to jemalloc 5.x. There is a separate PR for this fix in the master branch that works for version 4.x.

This PR also contains @mojodna's commits for the 5.0.0 binaries, with one corrected filename.