### PR TITLE
Add deprecation notice to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 I am a Heroku buildpack that installs
 [jemalloc](http://www.canonware.com/jemalloc/) into a dyno slug.
 
+## Unmaintained :wave:
+
+This Heroku buildpack is no longer actively maintained. It should continue to
+work but won't see changes as updates to Heroku or jemalloc are released.
+
+Consider switching to [gaffneyc/heroku-buildpack-jemalloc](https://github.com/gaffneyc/heroku-buildpack-jemalloc/)
+if you run into problems or want to try a [newer release of jemalloc](https://github.com/jemalloc/jemalloc/releases).
+
 ## Using
 
 To use jemalloc with your app, either prefix commands with `jemalloc.sh <cmd>`


### PR DESCRIPTION
It has been a few years since the last update and jemalloc has had
several releases in that time. I've been maintaining my fork and
provided support on it for a couple years now and I think it's time to
deprecate this one.

This buildpack has had a great life (and should continue to work as is)
but I think it's worth it to steer folks toward a maintained fork. For
example, it was recommended for Ruby to skip the 4.x branch and to stick
to 3.6.0 (released in 2015), but our team has had really good luck with
5.1.0 and 5.2.0.

There was a [pull request](https://github.com/mojodna/heroku-buildpack-jemalloc/pull/18) to merge the fork into the buildpack 
but given the risk it would expose anyone using the current
buildpack to I don't think it is a good path forward. For more
details see this comment: https://github.com/mojodna/heroku-buildpack-jemalloc/pull/18#issuecomment-434357178

@mojodna @nateberkopec thoughts?